### PR TITLE
try to fix memory leak in the locktable

### DIFF
--- a/include/utils/lock_table.h
+++ b/include/utils/lock_table.h
@@ -131,6 +131,10 @@ namespace pipeann {
       }
     }
     ~LockTable() {
+      for (size_t i = 0; i < size_; i++) {
+        pthread_rwlock_destroy(&locks_[i]);
+      }
+      delete[] locks_;
     }
 
     inline pthread_rwlock_t *rdlock(uint32_t key) {


### PR DESCRIPTION
The LockTable class was allocating an array of pthread_rwlock_t objects in its constructor but never freeing them in the destructor. This caused a 7MB memory leak detected by AddressSanitizer.